### PR TITLE
Added logic to check if href truly exists (in addition to if it's empty)

### DIFF
--- a/jquery.dropotron.js
+++ b/jquery.dropotron.js
@@ -467,7 +467,7 @@
 									return;
 							
 							// No href? Prevent default.
-								if ($(this).attr('href').length < 1)
+								if ( $(this).attr('href') == undefined || $(this).attr('href').length < 1)
 									e.preventDefault();
 
 						});
@@ -483,8 +483,9 @@
 							// If href is blank ("") or a hash (#), prevent the link from doing anything.
 								$a.on('click touchend', function(e) {
 									
-									if (href.length == 0
-									||	href == '#')
+                                    if (!href 
+                                    || href.length == 0
+                                    ||  href == '#')
 										e.preventDefault();
 									else
 										e.stopPropagation();


### PR DESCRIPTION
If your <a> tag doesn't have an href attribute, you'll get an Uncaught TypeError when clicking on the no-href-link. Checking for href.length doesn't suffice because href is technically undefined. I added two checks that ensure href exists in addition to checking if href.length has a value. This will prevent JS crashes when clicking on a link that has no href attribute
