### PR TITLE
Fix: use $(document).width() instead of $(window).width()

### DIFF
--- a/jquery.dropotron.js
+++ b/jquery.dropotron.js
@@ -96,6 +96,7 @@
 					$body = $('body'),
 					$bodyhtml = $('body,html'),
 					$window = $(window);
+					$document = $(document);
 
 				var	isLocked = false,
 					hoverTimeoutId = null,
@@ -205,7 +206,7 @@
 															c = 'left';
 
 														}
-														else if (left + mw > $window.width()) {
+														else if (left + mw > $document.width()) {
 
 															left = x.left - mw + ow;
 															c = 'right';
@@ -218,7 +219,7 @@
 													default:
 														left = x.left;
 
-														if (left + mw > $window.width()) {
+														if (left + mw > $document.width()) {
 
 															left = x.left - mw + ow;
 															c = 'right';
@@ -302,7 +303,7 @@
 											tmp = true;
 
 										}
-										else if ($menu.offset().left + mw > $window.width()) {
+										else if ($menu.offset().left + mw > $document.width()) {
 
 											left += (-1 * $opener.parent().outerWidth()) - settings.offsetX;
 											tmp = true;


### PR DESCRIPTION
$(window).width() refers to the width of the device's viewport.
$(document).width() refers to the width of the html content

When a browser window is reduced until the document content overflows the window, the values of $(window).width() and $(document).width() starts to diverge.

Also, on an iPhone 6, the $(window).width() is always 667, while the $(document).width() is the actual width of the HTML content. The HTML document pixels are "zoomed" to fit inside the iPhone 667 pixels (not sure what this means ?).